### PR TITLE
Style doc samples using black and flake8 and add validate action.

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Lint with flake8
         run: flake8 --count --verbose run.py
       - name: Check format with black
-        run: black --check --verbose run.py
+        run: black --check --verbose --line-length 79 run.py

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -24,6 +24,6 @@ jobs:
       - name: Install packages
         run: pip install black flake8
       - name: Lint with flake8
-        run: flake8 --count --verbose app.py
+        run: flake8 --count --verbose run.py
       - name: Check format with black
-        run: black --check --verbose app.py
+        run: black --check --verbose run.py

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,6 +1,6 @@
 name: Validate Python projects
 on:
-  push:
+  [workflow_dispatch, push]:
     branches:
       - doc-samples
 jobs:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,7 +1,6 @@
 name: Validate Python projects
 on: 
-  workflow_dispatch:
-  push:
+  pull_request:
     branches:
         - doc-samples
 jobs:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,6 +15,9 @@ jobs:
           - ./001-quickstart
           - ./101-client-connection-string
           - ./200-admin
+          - ./201-does-database-exist
+          - ./202-get-doc-count
+          - ./300-drop-database
     defaults:
       run:
         working-directory: ${{ matrix.project-directory }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,6 +1,8 @@
 name: Validate Python projects
 on:
     workflow_dispatch:
+        branches:
+            - doc-samples
     push:
         branches:
             - doc-samples
@@ -13,7 +15,7 @@ jobs:
       matrix:
         project-directory:
           - ./001-quickstart
-          - ./002-client-connection-string
+          - ./101-client-connection-string
     defaults:
       run:
         working-directory: ${{ matrix.project-directory }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,6 +14,7 @@ jobs:
         project-directory:
           - ./001-quickstart
           - ./101-client-connection-string
+          - ./200-admin
     defaults:
       run:
         working-directory: ${{ matrix.project-directory }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,6 +1,6 @@
 name: Validate Python projects
 on:
-  pull_request:
+  push:
     branches:
       - doc-samples
 jobs:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,7 +2,7 @@ name: Validate Python projects
 on: 
   pull_request:
     branches:
-        - doc-samples
+        - main
 jobs:
   validate:
     name: Validate Python project

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,11 +1,9 @@
 name: Validate Python projects
-on:
-    workflow_dispatch:
-        branches:
-            - doc-samples
-    push:
-        branches:
-            - doc-samples
+on: 
+  workflow_dispatch:
+  push:
+    branches:
+        - doc-samples
 jobs:
   validate:
     name: Validate Python project

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,29 @@
+name: Validate Python projects
+on:
+  pull_request:
+    branches:
+      - doc-samples
+jobs:
+  validate:
+    name: Validate Python project
+    runs-on: ubuntu-latest
+    container: python:3.7
+    strategy:
+      matrix:
+        project-directory:
+          - ./001-quickstart
+          - ./002-client-connection-string
+    defaults:
+      run:
+        working-directory: ${{ matrix.project-directory }}
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v2
+      - name: Check Python version
+        run: python --version
+      - name: Install packages
+        run: pip install black flake8
+      - name: Lint with flake8
+        run: flake8 --count --verbose app.py
+      - name: Check format with black
+        run: black --check --verbose app.py

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,8 +1,9 @@
 name: Validate Python projects
 on:
-  [workflow_dispatch, push]:
-    branches:
-      - doc-samples
+    workflow_dispatch:
+    push:
+        branches:
+            - doc-samples
 jobs:
   validate:
     name: Validate Python project

--- a/001-quickstart/run.py
+++ b/001-quickstart/run.py
@@ -68,7 +68,8 @@ def main():
     collection = db[COLLECTION_NAME]
     if COLLECTION_NAME not in db.list_collection_names():
         # Creates a unsharded collection that uses the DBs shared throughput
-        db.command({"customAction": "CreateCollection", "collection": COLLECTION_NAME})
+        db.command({"customAction": "CreateCollection", 
+                    "collection": COLLECTION_NAME})
         print("Created collection '{}'.\n".format(COLLECTION_NAME))
     else:
         print("Using collection: '{}'.\n".format(COLLECTION_NAME))
@@ -112,7 +113,8 @@ def main():
     """Query for documents in the collection"""
     print("Products with category 'gear-surf-surfboards':\n")
     allProductsQuery = {"category": "gear-surf-surfboards"}
-    for doc in collection.find(allProductsQuery).sort("name", pymongo.ASCENDING):
+    for doc in collection.find(allProductsQuery) \
+                         .sort("name", pymongo.ASCENDING):
         print("Found a product with _id {}: {}\n".format(doc["_id"], doc))
     # </query_docs>
 

--- a/001-quickstart/run.py
+++ b/001-quickstart/run.py
@@ -1,13 +1,13 @@
-# ----------------------------------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 #  Prerequisites:
 #
 # 1. An Azure Cosmos DB API for MongoDB Account.
 # 2. PyMongo installed.
 # 3. python-dotenv installed (to load environment variables from a .env file).
-# ----------------------------------------------------------------------------------------------------------
-# Sample - demonstrates the basic CRUD operations on a document in the Azure Cosmos DB API for MongoDB
+# -----------------------------------------------------------------------------
+# Sample - shows doc CRUD operations oin the Azure Cosmos DB API for MongoDB
 #        - for use in quickstart article
-# ----------------------------------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
 # <package_dependencies>
 import os
@@ -32,7 +32,9 @@ COLLECTION_NAME = "products"
 
 
 def main():
-    """Connect to the API for MongoDB, create DB and collection, perform CRUD operations"""
+    """Connect to the API for MongoDB, create DB and collection, 
+       perform CRUD operations
+    """
 
     try:
         # <connect_client>
@@ -53,7 +55,7 @@ def main():
     # Create database if it doesn't exist
     db = client[DB_NAME]
     if DB_NAME not in client.list_database_names():
-        # Database with 400 RU throughput that can be shared across the DB's collections
+        # DB with 400 RU throughput that can be shared across the DB's collections
         db.command({"customAction": "CreateDatabase", "offerThroughput": 400})
         print("Created db '{}' with shared throughput.\n".format(DB_NAME))
     else:
@@ -128,10 +130,20 @@ Indexes are: ['_id_', 'name_1']
 
 Upserted document with _id <ID>
 
-Found a document with _id <ID>: {'_id': <ID>, 'category': 'gear-surf-surfboards', 'name': 'Yamba Surfboard-50', 'quantity': 1, 'sale': False}
+Found a document with _id <ID>: 
+{'_id': <ID>, 
+'category': 'gear-surf-surfboards', 
+'name': 'Yamba Surfboard-50', 
+'quantity': 1, 
+'sale': False}
 
 Products with category 'gear-surf-surfboards':
 
-Found a product with _id <ID>: {'_id': ObjectId('<ID>'), 'name': 'Yamba Surfboard-386', 'category': 'gear-surf-surfboards', 'quantity': 1, 'sale': False}
+Found a product with _id <ID>: 
+{'_id': ObjectId('<ID>'),
+'name': 'Yamba Surfboard-386', 
+'category': 'gear-surf-surfboards', 
+'quantity': 1, 
+'sale': False}
 # </console_result>
 """

--- a/001-quickstart/run.py
+++ b/001-quickstart/run.py
@@ -68,7 +68,7 @@ def main():
     collection = db[COLLECTION_NAME]
     if COLLECTION_NAME not in db.list_collection_names():
         # Creates a unsharded collection that uses the DBs shared throughput
-        db.command({"customAction": "CreateCollection", 
+        db.command({"customAction": "CreateCollection",
                     "collection": COLLECTION_NAME})
         print("Created collection '{}'.\n".format(COLLECTION_NAME))
     else:
@@ -134,7 +134,7 @@ Indexes are: ['_id_', 'name_1']
 Upserted document with _id <ID>
 
 Found a document with _id <ID>:
-{'_id': <ID>, 
+{'_id': <ID>,
 'category': 'gear-surf-surfboards',
 'name': 'Yamba Surfboard-50',
 'quantity': 1,

--- a/001-quickstart/run.py
+++ b/001-quickstart/run.py
@@ -32,7 +32,7 @@ COLLECTION_NAME = "products"
 
 
 def main():
-    """Connect to the API for MongoDB, create DB and collection, 
+    """Connect to the API for MongoDB, create DB and collection,
        perform CRUD operations
     """
 
@@ -55,7 +55,8 @@ def main():
     # Create database if it doesn't exist
     db = client[DB_NAME]
     if DB_NAME not in client.list_database_names():
-        # DB with 400 RU throughput that can be shared across the DB's collections
+        # Create a database with 400 RU throughput that can be shared across
+        # the DB's collections
         db.command({"customAction": "CreateDatabase", "offerThroughput": 400})
         print("Created db '{}' with shared throughput.\n".format(DB_NAME))
     else:
@@ -130,20 +131,20 @@ Indexes are: ['_id_', 'name_1']
 
 Upserted document with _id <ID>
 
-Found a document with _id <ID>: 
+Found a document with _id <ID>:
 {'_id': <ID>, 
-'category': 'gear-surf-surfboards', 
-'name': 'Yamba Surfboard-50', 
-'quantity': 1, 
+'category': 'gear-surf-surfboards',
+'name': 'Yamba Surfboard-50',
+'quantity': 1,
 'sale': False}
 
 Products with category 'gear-surf-surfboards':
 
-Found a product with _id <ID>: 
+Found a product with _id <ID>:
 {'_id': ObjectId('<ID>'),
-'name': 'Yamba Surfboard-386', 
-'category': 'gear-surf-surfboards', 
-'quantity': 1, 
+'name': 'Yamba Surfboard-386',
+'category': 'gear-surf-surfboards',
+'quantity': 1,
 'sale': False}
 # </console_result>
 """

--- a/001-quickstart/run.py
+++ b/001-quickstart/run.py
@@ -33,7 +33,7 @@ COLLECTION_NAME = "products"
 
 def main():
     """Connect to the API for MongoDB, create DB and collection,
-       perform CRUD operations
+    perform CRUD operations
     """
 
     try:
@@ -68,8 +68,9 @@ def main():
     collection = db[COLLECTION_NAME]
     if COLLECTION_NAME not in db.list_collection_names():
         # Creates a unsharded collection that uses the DBs shared throughput
-        db.command({"customAction": "CreateCollection",
-                    "collection": COLLECTION_NAME})
+        db.command(
+            {"customAction": "CreateCollection", "collection": COLLECTION_NAME}
+        )
         print("Created collection '{}'.\n".format(COLLECTION_NAME))
     else:
         print("Using collection: '{}'.\n".format(COLLECTION_NAME))
@@ -113,8 +114,9 @@ def main():
     """Query for documents in the collection"""
     print("Products with category 'gear-surf-surfboards':\n")
     allProductsQuery = {"category": "gear-surf-surfboards"}
-    for doc in collection.find(allProductsQuery) \
-                         .sort("name", pymongo.ASCENDING):
+    for doc in collection.find(allProductsQuery).sort(
+        "name", pymongo.ASCENDING
+    ):
         print("Found a product with _id {}: {}\n".format(doc["_id"], doc))
     # </query_docs>
 

--- a/101-client-connection-string/run.py
+++ b/101-client-connection-string/run.py
@@ -1,15 +1,16 @@
-# ----------------------------------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
 #  Prerequisites:
 #
 # 1. An Azure Cosmos DB API for MongoDB Account.
 # 2. PyMongo installed.
 # 3. python-dotenv installed (to load environment variables from a .env file).
-# ----------------------------------------------------------------------------------------------------------
-# Code samples are used in documentation, do not change unless synchronizing with documentation.
-# ----------------------------------------------------------------------------------------------------------
+# ------------------------------------------------------------------------------
+# Code samples are used in documentation, keep synchronized with documentation.
+# ------------------------------------------------------------------------------
 
 # <package_dependencies>
 import os
+import sys
 
 import pymongo
 from dotenv import load_dotenv
@@ -50,12 +51,21 @@ if __name__ == "__main__":
 
 """
 # <console_result>
-Property: _ClientOptions__options: Value: {'replicaSet': 'globaldb', 'retrywrites': False, 'maxIdleTimeMS': 120.0, 'appName': '@cosmosdb-mongodb@', 'document_class': <class 'dict'>, 'tz_aware': False, 'connect': True, 'tls': True}
-Property: _ClientOptions__codec_options: Value: CodecOptions(document_class=dict, tz_aware=False, uuid_representation=UuidRepresentation.UNSPECIFIED, unicode_decode_error_handler='strict', tzinfo=None, type_registry=TypeRegistry(type_codecs=[], fallback_encoder=None), datetime_conversion=DatetimeConversion.DATETIME)
+Property: _ClientOptions__options: Value:
+{'replicaSet': 'globaldb', 'retrywrites': False, 'maxIdleTimeMS': 120.0,
+'appName': '@cosmosdb-mongodb@', 'document_class': <class 'dict'>,
+'tz_aware': False, 'connect': True, 'tls': True}
+Property: _ClientOptions__codec_options: Value:
+CodecOptions(document_class=dict, tz_aware=False,
+uuid_representation=UuidRepresentation.UNSPECIFIED,
+unicode_decode_error_handler='strict', tzinfo=None,
+type_registry=TypeRegistry(type_codecs=[], fallback_encoder=None),
+datetime_conversion=DatetimeConversion.DATETIME)
 Property: _ClientOptions__direct_connection: Value: None
 Property: _ClientOptions__local_threshold_ms: Value: 15
 Property: _ClientOptions__server_selection_timeout: Value: 30
-Property: _ClientOptions__pool_options: Value: <pymongo.pool.PoolOptions object at 0x0000013AC16A9170>
+Property: _ClientOptions__pool_options: Value:
+  <pymongo.pool.PoolOptions object at 0x0000013AC16A9170>
 Property: _ClientOptions__read_preference: Value: Primary()
 Property: _ClientOptions__replica_set_name: Value: globaldb
 Property: _ClientOptions__write_concern: Value: WriteConcern()
@@ -64,7 +74,8 @@ Property: _ClientOptions__connect: Value: True
 Property: _ClientOptions__heartbeat_frequency: Value: 10
 Property: _ClientOptions__retry_writes: Value: False
 Property: _ClientOptions__retry_reads: Value: True
-Property: _ClientOptions__server_selector: Value: <function any_server_selector at 0x0000013AC104F490>
+Property: _ClientOptions__server_selector: Value:
+  <function any_server_selector at 0x0000013AC104F490>
 Property: _ClientOptions__auto_encryption_opts: Value: None
 Property: _ClientOptions__load_balanced: Value: None
 Property: _ClientOptions__timeout: Value: None

--- a/200-admin/run.py
+++ b/200-admin/run.py
@@ -1,12 +1,12 @@
-# ----------------------------------------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 #  Prerequisites:
 #
 # 1. An Azure Cosmos DB API for MongoDB Account.
 # 2. PyMongo installed.
 # 3. python-dotenv installed (to load environment variables from a .env file).
-# ----------------------------------------------------------------------------------------------------------
-# Code samples are used in documentation, do not change unless synchronizing with documentation.
-# ----------------------------------------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
+# Code samples are used in documentation, keep synchronized with docs.
+# ----------------------------------------------------------------------------
 
 import os
 import sys

--- a/201-does-database-exist/run.py
+++ b/201-does-database-exist/run.py
@@ -1,12 +1,12 @@
-# ----------------------------------------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 #  Prerequisites:
 #
 # 1. An Azure Cosmos DB API for MongoDB Account.
 # 2. PyMongo installed.
 # 3. python-dotenv installed (to load environment variables from a .env file).
-# ----------------------------------------------------------------------------------------------------------
-# Code samples are used in documentation, do not change unless synchronizing with documentation.
-# ----------------------------------------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
+# Code samples are used in documentation, keep synchronized with docs.
+# ----------------------------------------------------------------------------
 
 import os
 import sys
@@ -23,7 +23,7 @@ def main():
         CONNECTION_STRING = os.environ.get("COSMOS_CONNECTION_STRING")
         client = pymongo.MongoClient(CONNECTION_STRING)
 
-        # <does_database_exist> 
+        # <does_database_exist>
         # Get list of databases
         databases = client.list_database_names()
         if not databases:
@@ -34,7 +34,9 @@ def main():
         if DB_NAME in databases:
             print("Database exists: {}".format(DB_NAME))
         else:
-            client[DB_NAME].command({"customAction": "CreateDatabase", "offerThroughput": 400})
+            client[DB_NAME].command(
+                {"customAction": "CreateDatabase", "offerThroughput": 400}
+            )
             print("Created db '{}' with shared throughput.\n".format(DB_NAME))
         # </does_database_exist>
 
@@ -43,7 +45,9 @@ def main():
         if COLL_NAME in client[DB_NAME].list_collection_names():
             print("Collection exists: {}".format(COLL_NAME))
         else:
-            client[DB_NAME].command({"customAction": "CreateCollection", "collection": COLL_NAME})
+            client[DB_NAME].command(
+                {"customAction": "CreateCollection", "collection": COLL_NAME}
+            )
             print("Created collection '{}'.\n".format(COLL_NAME))
         # </does_collection_exist>
 
@@ -59,6 +63,7 @@ def main():
         sys.exit("Error:" + str(err))
 
     client.close()
+
 
 if __name__ == "__main__":
     main()

--- a/202-get-doc-count/run.py
+++ b/202-get-doc-count/run.py
@@ -1,12 +1,12 @@
-# ----------------------------------------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 #  Prerequisites:
 #
 # 1. An Azure Cosmos DB API for MongoDB Account.
 # 2. PyMongo installed.
 # 3. python-dotenv installed (to load environment variables from a .env file).
-# ----------------------------------------------------------------------------------------------------------
-# Code samples are used in documentation, do not change unless synchronizing with documentation.
-# ----------------------------------------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
+# Code samples are used in documentation, keep synchronized with docs.
+# ----------------------------------------------------------------------------
 
 import os
 import sys
@@ -55,6 +55,7 @@ def main():
         sys.exit("Error:" + str(err))
 
     client.close()
+
 
 if __name__ == "__main__":
     main()

--- a/300-drop-database/run.py
+++ b/300-drop-database/run.py
@@ -1,12 +1,12 @@
-# ----------------------------------------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 #  Prerequisites:
 #
 # 1. An Azure Cosmos DB API for MongoDB Account.
 # 2. PyMongo installed.
 # 3. python-dotenv installed (to load environment variables from a .env file).
-# ----------------------------------------------------------------------------------------------------------
-# Code samples are used in documentation, do not change unless synchronizing with documentation.
-# ----------------------------------------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
+# Code samples are used in documentation, keep synchronized with docs.
+# ----------------------------------------------------------------------------
 
 import os
 import sys

--- a/README.md
+++ b/README.md
@@ -18,3 +18,5 @@ Prerequisites:
 Use `python run.py` to run the code samples. 
 
 Make sure you define an *.env* variable with the connection string if needed for a sample.
+
+Small change.

--- a/README.md
+++ b/README.md
@@ -18,5 +18,3 @@ Prerequisites:
 Use `python run.py` to run the code samples. 
 
 Make sure you define an *.env* variable with the connection string if needed for a sample.
-
-Small change.

--- a/run.py
+++ b/run.py
@@ -3,73 +3,107 @@ import pymongo
 
 from random import randint
 
-# ----------------------------------------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 #  Prerequisites:
 #
 # 1. An Azure Cosmos DB API for MongoDB Account.
 # 2. PyMongo installed.
-# ----------------------------------------------------------------------------------------------------------
-# Sample - demonstrates the basic CRUD operations on a document in the Azure Cosmos DB API for MongoDB
-# ----------------------------------------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
+# Sample - demonstrates the basic CRUD operations on a document in the
+# Azure Cosmos DB API for MongoDB.
+# ----------------------------------------------------------------------------
 
-CONNECTION_STRING = getpass.getpass(prompt='Enter your primary connection string: ') # Prompts user for connection string
+CONNECTION_STRING = getpass.getpass(
+    prompt="Enter your primary connection string: "
+)  # Prompts user for connection string
 DB_NAME = "api-mongodb-sample-database"
 UNSHARDED_COLLECTION_NAME = "unsharded-sample-collection"
 SAMPLE_FIELD_NAME = "sample_field"
+
 
 def delete_document(collection, document_id):
     """Delete the document containing document_id from the collection"""
     collection.delete_one({"_id": document_id})
     print("Deleted document with _id {}".format(document_id))
 
+
 def read_document(collection, document_id):
     """Return the contents of the document containing document_id"""
-    print("Found a document with _id {}: {}".format(document_id, collection.find_one({"_id": document_id})))
+    print(
+        "Found a document with _id {}: {}".format(
+            document_id, collection.find_one({"_id": document_id})
+        )
+    )
+
 
 def update_document(collection, document_id):
     """Update the sample field value in the document containing document_id"""
-    collection.update_one({"_id": document_id}, {"$set":{SAMPLE_FIELD_NAME: "Updated!"}})
-    print("Updated document with _id {}: {}".format(document_id, collection.find_one({"_id": document_id})))
+    collection.update_one(
+        {"_id": document_id}, {"$set": {SAMPLE_FIELD_NAME: "Updated!"}}
+    )
+    print(
+        "Updated document with _id {}: {}".format(
+            document_id, collection.find_one({"_id": document_id})
+        )
+    )
+
 
 def insert_sample_document(collection):
     """Insert a sample document and return the contents of its _id field"""
-    document_id = collection.insert_one({SAMPLE_FIELD_NAME: randint(50, 500)}).inserted_id
+    document_id = collection.insert_one(
+        {SAMPLE_FIELD_NAME: randint(50, 500)}
+    ).inserted_id
     print("Inserted document with _id {}".format(document_id))
     return document_id
 
+
 def create_database_unsharded_collection(client):
-    """Create sample database with shared throughput if it doesn't exist and an unsharded collection"""
+    """Create sample database with shared throughput if it doesn't exist and
+    an unsharded collection
+    """
     db = client[DB_NAME]
 
     # Create database if it doesn't exist
     if DB_NAME not in client.list_database_names():
-        # Database with 400 RU throughput that can be shared across the DB's collections
-        db.command({'customAction': "CreateDatabase", 'offerThroughput': 400})
-        print("Created db {} with shared throughput". format(DB_NAME))
-    
+        # Database with 400 RU throughput that can be shared across the
+        # DB's collections
+        db.command({"customAction": "CreateDatabase", "offerThroughput": 400})
+        print("Created db {} with shared throughput".format(DB_NAME))
+
     # Create collection if it doesn't exist
     if UNSHARDED_COLLECTION_NAME not in db.list_collection_names():
         # Creates a unsharded collection that uses the DBs shared throughput
-        db.command({'customAction': "CreateCollection", 'collection': UNSHARDED_COLLECTION_NAME})
-        print("Created collection {}". format(UNSHARDED_COLLECTION_NAME))
-    
+        db.command(
+            {
+                "customAction": "CreateCollection",
+                "collection": UNSHARDED_COLLECTION_NAME,
+            }
+        )
+        print("Created collection {}".format(UNSHARDED_COLLECTION_NAME))
+
     return db[UNSHARDED_COLLECTION_NAME]
 
+
 def main():
-    """Connect to the API for MongoDB, create DB and collection, perform CRUD operations"""
+    """Connect to the API for MongoDB, create DB and collection, perform
+    CRUD operations
+    """
     client = pymongo.MongoClient(CONNECTION_STRING)
     try:
-        client.server_info() # validate connection string
+        client.server_info()  # validate connection string
     except pymongo.errors.ServerSelectionTimeoutError:
-        raise TimeoutError("Invalid API for MongoDB connection string or timed out when attempting to connect")
+        raise TimeoutError(
+            "Invalid API for MongoDB connection string \
+                or timed out when attempting to connect"
+        )
 
     collection = create_database_unsharded_collection(client)
     document_id = insert_sample_document(collection)
-    
+
     read_document(collection, document_id)
     update_document(collection, document_id)
     delete_document(collection, document_id)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
Fix example syntax and create validate github action.

Based validate.yml on this https://github.com/Azure-Samples/cosmos-db-nosql-python-samples/blob/main/.github/workflows/validate.yml

The only difference is that the validate.yml in this PR has "black" set with line length of 79 which matches what "flake8" uses.

Run all samples again "python run.py" to verify changes didn't impact functionality.