### PR TITLE
Small correction of the definition of the second index in the indexes list

### DIFF
--- a/001-quickstart/run.py
+++ b/001-quickstart/run.py
@@ -79,7 +79,7 @@ def main():
     # <create_index>
     indexes = [
         {"key": {"_id": 1}, "name": "_id_1"},
-        {"key": {"name": 2}, "name": "_id_2"},
+        {"key": {"name": 1}, "name": "name_1"},
     ]
     db.command(
         {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* I noticed that the previous code had an issue in the definition of the second index in the indexes list. The previous code didn't cause any error when running the app, however, by correcting the index definition we ensure that the Python code is written correctly and that the ouput of the code matches the expected output.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone https://github.com/dom-arm/azure-cosmos-db-mongodb-python-getting-started-fork.git
cd azure-cosmos-db-mongodb-python-getting-started-fork
git checkout fix-indexes
pip install -r requirements.txt
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
This is such a small change, but you could manually test it by running the app and compare that the output corresponds to the expected output on line 134

## What to Check
Verify that the following are valid
* The output of the app now include this line: "Indexes are: ['_id_', 'name_1']" instead of the previous wrong output: "Indexes are: ['_id_', '_id_2']"

## Other Information
<!-- Add any other helpful information that may be needed here. -->
No additions